### PR TITLE
build(deps): upgraded arc-swap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 slog = "2.5"
-arc-swap = "0.4"
+arc-swap = "1.1.0"
 lazy_static = "1.4"
 log = { version = "0.4", optional = true }
 

--- a/lib.rs
+++ b/lib.rs
@@ -45,7 +45,7 @@ pub fn get_global() -> Arc<Logger> {
 }
 
 /// Temporary borrows the global `Logger`.
-pub fn borrow_global<'a>() -> Guard<'a, Arc<Logger>> {
+pub fn borrow_global<'a>() -> Guard<Arc<Logger>> {
     GLOBAL_LOGGER.load()
 }
 


### PR DESCRIPTION
upgraded arc-swap from v0.4.8 to v1.8.0；
replace `Guard<'a, T>` with `Guard<T>` in lib.rs to make `cargo build` succeed.